### PR TITLE
ci: use `#` as version separator for root crate

### DIFF
--- a/.github/workflows/wadge.yml
+++ b/.github/workflows/wadge.yml
@@ -347,7 +347,7 @@ jobs:
 
       - name: publish wadge to crates.io
         run: |
-          pkgver=$(cargo pkgid | cut -d '@' -f 2)
+          pkgver=$(cargo pkgid | cut -d '#' -f 2)
           tagver="${{ steps.ctx.outputs.version }}"
           if ! [ "$pkgver" = "$tagver" ]; then
             echo "version mismatch, $pkgver (package) != $tagver (tag)"


### PR DESCRIPTION
See https://github.com/bytecodealliance/wrpc/pull/342